### PR TITLE
Fixed Small Icon Bug

### DIFF
--- a/EZBlocker/EZBlocker/Form1.cs
+++ b/EZBlocker/EZBlocker/Form1.cs
@@ -421,6 +421,10 @@ namespace EZBlocker
                 this.FormBorderStyle = FormBorderStyle.FixedToolWindow;
                 Notify("EZBlocker is hidden. Double-click this icon to restore.");
             }
+            if (this.WindowState == FormWindowState.Normal)
+            {
+                this.FormBorderStyle = FormBorderStyle.FixedSingle;
+            }
         }
 
         private void SpotifyMuteCheckBox_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Icon was not appearing after reopening EZBlocker from the system tray.
This was fixed by setting the FormBorderStyle back to its default value
of FixedSingle whenever the WindowState is set to Normal.
